### PR TITLE
Fix leftover merge conflict in analyze.js

### DIFF
--- a/api/analyze.js
+++ b/api/analyze.js
@@ -1,7 +1,6 @@
 const { default: chromium } = require('@sparticuz/chromium-min');
 const puppeteer = require('puppeteer-core');
 const { createWorker } = require('tesseract.js');
-const path = require("node:path");
 
 module.exports = async (req, res) => {
   if (req.method !== 'POST') {


### PR DESCRIPTION
## Summary
- remove unused `path` import from `analyze.js`

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6863e39c8a70832e96163bc805577ab2